### PR TITLE
Add Prettier standard config

### DIFF
--- a/prettier/README.md
+++ b/prettier/README.md
@@ -1,0 +1,17 @@
+# @bufferapp/prettier-config
+
+This is the standard Prettier config file for the projects within the @bufferapp GitHub organization.
+
+## Usage
+
+```shell script
+> npm install --save-dev @bufferapp/prettier-config
+# or
+> yarn add -D @bufferapp/prettier-config
+```
+
+And then, on your `package.json` use
+
+```json
+"prettier": "@bufferapp/prettier-config"
+```

--- a/prettier/index.js
+++ b/prettier/index.js
@@ -1,0 +1,5 @@
+module.exports = {
+    semi: false,
+    singleQuote: true,
+    trailingComma: "es5",
+}

--- a/prettier/package-lock.json
+++ b/prettier/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "@bufferapp/prettier-config",
+  "version": "0.0.1",
+  "lockfileVersion": 1
+}

--- a/prettier/package.json
+++ b/prettier/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@bufferapp/prettier-config",
+  "version": "0.0.1",
+  "description": "Buffer standard Prettier configuration",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Mike San Román <mike@msanroman.io>",
+  "license": "ISC",
+  "peerDependencies": {
+    "prettier": "^2.0.5"
+  }
+}


### PR DESCRIPTION
## PR

This is the standard Prettier config file for the projects within the https://github.com/bufferapp GitHub organization.

This was created by taking a look at [Account](https://github.com/bufferapp/buffer-account), [Publish](https://github.com/bufferapp/buffer-publish), [Authentication Service](https://github.com/bufferapp/core-authentication-service), [Engage (backend)](https://github.com/bufferapp/buffer-engage-backend), and [Engage (frontend)](https://github.com/bufferapp/buffer-engage-frontend) and aiming for a minimal version that relies on Pretier defaults and uses the most common settings set already by our different teams.

There were repositories setting items with default values, such as `tabWidth
: 2`  or `bracketSpacing: true`.

This configuration omits any default setting for now.



